### PR TITLE
update and test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.20-alpine
 
 RUN apk update && \
     apk add --no-cache --virtual build-dependancies \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.13-alpine
+FROM golang:alpine
 
 RUN apk update && \
     apk add --no-cache --virtual build-dependancies \
     build-base gcc wget git bash && \
-    apk add --no-cache openjdk8 && \
+    apk add --no-cache openjdk17 && \
     git clone https://github.com/gocd-contrib/gocd-cli.git && \
     cd gocd-cli && ./build.sh && \
     mv gocd /usr/local/bin && chmod +x /usr/local/bin/gocd && \
@@ -11,6 +11,10 @@ RUN apk update && \
     apk del build-dependancies && \
     rm -rf /var/cache/apk/* && \
     rm -rf /var/lib/apt/lists/*
+
+# Testing
+COPY pipeline-test.yml /root/
+RUN gocd configrepo --yaml syntax /root/pipeline-test.yml --debug
 
 ENTRYPOINT ["gocd"]
 CMD ["--version"]

--- a/pipeline-test.yml
+++ b/pipeline-test.yml
@@ -1,0 +1,20 @@
+format_version: 4
+pipelines:
+  docker-gocd-cli:
+    materials:
+      git:
+        type: configrepo
+        auto_update: false
+    group: Test
+    label_template: '${COUNT}-${git[:7]}'
+    locking: off
+    stages:
+      - test:
+          clean_workspace: true
+          jobs:
+            test:
+              tasks:
+                - exec:
+                    command: make
+                    arguments:
+                      - test


### PR DESCRIPTION
This PR upgrades alpine and Java, and adds basic test.

Java upgrade is required because newly plugins are built using recent version of Java. Behind the scene, `gocd-cli` [calls Java](https://github.com/gocd-contrib/gocd-cli/blob/master/cmd/configrepo/syntax.go#L38 ) `cmd := exec.Command("java", cmdArgs...)`. The Java command looks like this `java -jar /root/.gocd/plugins/yaml-config-plugin-0.12.0.jar syntax pipeline.yml`. Running this command with an older version of Java returns the following error: `YamlPluginCli has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0`